### PR TITLE
display correct human attribute name

### DIFF
--- a/lib/deep_unrest.rb
+++ b/lib/deep_unrest.rb
@@ -461,7 +461,8 @@ module DeepUnrest
                               field_name].reject(&:empty?).compact.join('.')
         deep_unrest_path = [operation[:dr_error_key],
                             field_name].compact.join('.')
-        { title: "#{path_info[:field].humanize} #{format_error_title(msg)}",
+        attribute_name = operation[:type].classify.constantize.human_attribute_name(path_info[:field])
+        { title: "#{attribute_name} #{format_error_title(msg)}",
           detail: msg,
           source: { pointer: pointer,
                     deepUnrestPath: deep_unrest_path,


### PR DESCRIPTION
When we customize the validation message in locales/en.yml, the ActiveRecord validation message should be changed. For example we have

```
en:
  activerecord:
    attributes:
      submission:
        chla_domain: 'Domain'
```

This should generate 'Domain is invalid' instead of 'Chla domain is invalid' when the chla_domain is invalid.